### PR TITLE
feat: add Storybook design polisher skill

### DIFF
--- a/skills/storybook-design-polisher/SKILL.md
+++ b/skills/storybook-design-polisher/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: storybook-design-polisher
+description: Storybook を `cdpb` で起動した Chrome dev browser と CDP 経由で監査し、component-first で UI を改善する skill。`$storybook-design-polisher` または正確な skill 名が明示されたときだけ使い、`pnpm storybook` の起動、`localhost:6006` の確認、指定 story または story 一覧の監査、primitive/shared-component と composed-story の修正分離、改善案の実装と再確認を行う。
+---
+
+# Storybook Design Polisher
+
+Storybook をレビュー面にし、design-system の階層を正本として扱う。まず最小の再利用コンポーネントから見て、primitive や shared component の修正で解決しない場合だけ上位 composition へ進む。
+
+## クイックスタート
+
+1. 監査対象を確定する。指定 story のみか、sidebar 全体かを先に決める。
+2. 起動と接続の具体手順は [references/session-bootstrap.md](references/session-bootstrap.md) を読む。
+3. story 名の指定がなければ、sidebar を最小 primitive から上位 composition へ順にたどる。
+4. 最小責務レイヤの判断と監査観点は [references/review-flow.md](references/review-flow.md) を読む。
+5. 最小責務レイヤだけを直し、直後に同じ story を再確認する。
+
+## スコープと順序
+
+- user が story を指定した場合は、その story だけを監査する。ただし upstream primitive に原因があるのが明白ならそこまでは遡る。
+- scope が "all" の場合は、sidebar を次の順で見る:
+  1. primitive と単機能の shared component
+  2. 同一 component の variant と state
+  3. 複数 component を束ねた shared block
+  4. app-level composition
+- 再利用 component の修正と composed story の修正は別 workstream として扱い、先に再利用 component 側を終える。
+
+## 監査ループ
+
+1. story の現状を確認し、客観的な問題を列挙する。
+2. 問題を token、shared component、composition、fixture に分類する。
+3. 編集前に story source、実装 file、周辺 token を確認する。
+4. 客観的な defect なら red-first を優先する。自動 assertion に落とせない純 visual issue はその制約を明記する。
+5. 変更後に同じ story を開き直して比較する。
+6. 再利用 component 側がきれいになってから、まだ違和感が残る composed story を調整する。
+
+## 指摘と報告
+
+- full pass をするとき、または原因がはっきりしないときは [references/visual-audit-checklist.md](references/visual-audit-checklist.md) を読む。
+- facts と speculation を分けて報告する:
+  - facts: Storybook または code から直接確認できた内容。story 名と file path を付ける
+  - speculation: `Possibly` または `Likely` を付け、何を確認すれば確定できるかを書く
+- 典型的な違和感の詳細は [references/visual-audit-checklist.md](references/visual-audit-checklist.md) に寄せる。
+
+## 検証
+
+- 意味のある変更 batch ごとに、対象 story を CDP 経由で再確認する。
+- code 変更後は関連する自動チェックを回す。
+- この repo の推奨 verify commands は [references/review-flow.md](references/review-flow.md) に置く。
+- 実行しなかった command があれば理由を明記する。
+
+## 必要なときだけ読む
+
+- layer ownership の判断には `docs/design-system/source-of-truth.md` を使う。
+- Storybook と Playwright の責務分離には `docs/workflows/qa-strategy.md` を使う。
+- 修正先が `packages/ui/` か app-local code か迷ったら `docs/architecture/repository-map.md` を使う。

--- a/skills/storybook-design-polisher/agents/openai.yaml
+++ b/skills/storybook-design-polisher/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Storybook デザイン磨き"
+  short_description: "Storybook を CDP 監査して改善する"
+  default_prompt: "$storybook-design-polisher を使って Storybook を CDP 経由で監査し、最小の shared component から順に改善してください。"
+policy:
+  allow_implicit_invocation: false

--- a/skills/storybook-design-polisher/references/review-flow.md
+++ b/skills/storybook-design-polisher/references/review-flow.md
@@ -1,0 +1,32 @@
+# Review Flow
+
+## レイヤ判断
+
+- token の問題 -> `packages/design-tokens/`
+- shared primitive / shared component の問題 -> `packages/ui/`
+- app-local composition の問題 -> `components/`, `features/`, `app/`
+
+同じ defect が複数 story に出るなら、できるだけ下位レイヤへ fix を降ろす。
+
+## 監査の見方
+
+1. story の現状を確認する。
+2. 問題を token、shared component、composition、fixture に分類する。
+3. story source と実装 file を読み、原因が最小レイヤのどこにあるか確定する。
+4. red-first にできる defect なら test か story coverage を先に足す。
+5. 最小変更で直し、同じ story を再確認する。
+6. shared component 側が整ってから composed story を触る。
+
+## verify commands
+
+```bash
+pnpm lint:framework
+pnpm lint
+pnpm format:check
+pnpm test
+pnpm typecheck
+pnpm build
+pnpm build-storybook
+```
+
+実行しなかった command があれば理由を書く。

--- a/skills/storybook-design-polisher/references/session-bootstrap.md
+++ b/skills/storybook-design-polisher/references/session-bootstrap.md
@@ -1,0 +1,39 @@
+# Session Bootstrap
+
+## 目的
+
+`cdpb` で Chrome dev browser を立ち上げ、`pnpm storybook` を起動し、CDP 経由で `localhost:6006` を開く。
+
+## 手順
+
+1. dev browser を起動する。
+
+```bash
+zsh -ic 'cdpb about:blank'
+```
+
+2. repo root で Storybook を起動する。
+
+```bash
+pnpm storybook
+```
+
+3. Storybook の待機には `scripts/wait-for-storybook.sh` を使う。
+
+```bash
+./skills/storybook-design-polisher/scripts/wait-for-storybook.sh
+```
+
+4. CDP 経由で Storybook を開く。`agent-browser` が使えるならそれを優先する。
+
+```bash
+agent-browser --cdp 9222 open http://127.0.0.1:6006
+agent-browser --cdp 9222 wait --load networkidle
+agent-browser --cdp 9222 snapshot -i
+```
+
+## fallback
+
+- `agent-browser` が使えないなら Playwright MCP で `http://127.0.0.1:6006` を開く。
+- `cdpb` が見つからないなら `~/.zshrc` の alias 定義を確認する。
+- port が埋まっているなら既存の Storybook や Chrome dev profile の残骸を疑う。

--- a/skills/storybook-design-polisher/references/visual-audit-checklist.md
+++ b/skills/storybook-design-polisher/references/visual-audit-checklist.md
@@ -1,0 +1,45 @@
+# Visual Audit Checklist
+
+Storybook を一通り監査するとき、または違和感はあるが原因が曖昧なときにこの checklist を使う。
+
+## 1. Hierarchy
+
+- 見た目の重さは component の役割に合っているか。
+- color に頼らなくても typography hierarchy が伝わるか。
+- 装飾要素が主役の action や content を食っていないか。
+
+## 2. Spacing and Alignment
+
+- component family 内で gap が一貫しているか。
+- text baseline、icon、control がきれいに揃っているか。
+- sibling variant と比べて詰まりすぎ、または空きすぎになっていないか。
+
+## 3. Container Fit
+
+- narrow、typical、wide の各幅で破綻しないか。
+- label、helper text、badge、icon が欠けたり不自然に折り返したりしていないか。
+- 余白が偶然ではなく意図として見えるか。
+
+## 4. States
+
+- hover、focus、active、selected、disabled、loading、error が十分見えるか。
+- state 変化で layout が不安定になっていないか。
+- variant 同士が同じ component family に見えるか。
+
+## 5. Accessibility Signals
+
+- body text、muted text、control の contrast は十分そうか。
+- focus indicator が browser default 任せにならず見えるか。
+- target size が pointer と touch の両方で十分か。
+
+## 6. Token Drift
+
+- 単発の color、radius、shadow、spacing 値が入り込んでいないか。
+- 問題は token、shared primitive、local composition のどこに属するか。
+- 同じ defect が複数 story に出るなら、fix を shared layer 側へ降ろす。
+
+## 7. Composition Boundary
+
+- composed story なら、子 component の修正でより広く解決できないか。
+- 違和感の原因は component 自体ではなく layout composition ではないか。
+- 再利用 component の修正と composed-story cleanup は分け、先に再利用側を終える。

--- a/skills/storybook-design-polisher/scripts/wait-for-storybook.sh
+++ b/skills/storybook-design-polisher/scripts/wait-for-storybook.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+url="${1:-http://127.0.0.1:6006}"
+timeout_seconds="${2:-60}"
+
+if ! [[ "$timeout_seconds" =~ ^[0-9]+$ ]]; then
+  echo "timeout_seconds must be an integer" >&2
+  exit 2
+fi
+
+start_time="$(date +%s)"
+
+while true; do
+  if curl --silent --fail --output /dev/null "$url"; then
+    echo "Storybook is ready: $url"
+    exit 0
+  fi
+
+  now="$(date +%s)"
+  elapsed="$((now - start_time))"
+  if (( elapsed >= timeout_seconds )); then
+    echo "Timed out waiting for Storybook: $url" >&2
+    exit 1
+  fi
+
+  sleep 1
+done


### PR DESCRIPTION
## Summary
- add a local skill for Storybook visual audits through CDP
- define the review flow, ownership rules, and verification commands
- include a helper script that waits for Storybook on port 6006

## Changes
- added `skills/storybook-design-polisher/SKILL.md`
- added `agents/openai.yaml` for explicit invocation metadata
- added references for session bootstrap, review flow, and visual audit checklist
- added `scripts/wait-for-storybook.sh`

## Validation
- `pnpm build`
- `pnpm lint:framework`
- `pnpm test`
