### PR TITLE
chore(workflow): PRテンプレート運用を追加

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+# PR Template
+
+## Summary
+
+-
+
+## Changes
+
+-
+
+## Testing
+
+- [ ] `pnpm lint:framework`
+- [ ] `pnpm lint`
+- [ ] `pnpm format:check`
+- [ ] `pnpm test`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm build`
+
+## Notes
+
+-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Wireframes and mockups are advisory only.
 - Hook installation should remain on `prepare`; do not introduce `make init` only to wrap existing `pnpm` workflows.
 - `pre-commit` must format staged TypeScript files with Biome and staged non-TypeScript files with Prettier.
 - `pre-push` must run `pnpm lint:framework`, `pnpm test`, and `pnpm build`, and block pushes on failure.
+- When creating a PR, start from `.github/pull_request_template.md` and pass the body via `gh pr create --body-file ...` instead of an inline body string.
 - Storybook should use `defineMain`, `definePreview`, and `preview.meta -> meta.story` instead of legacy default-export CSF files.
 - For ad hoc browser exploration in dev mode, prefer `cdpb` with the `agent-browser` skill over Playwright MCP when possible.
 - Use Playwright spec files for durable regression coverage, CI, and reviewable browser behavior contracts.

--- a/docs/workflows/change-workflow.md
+++ b/docs/workflows/change-workflow.md
@@ -43,3 +43,9 @@ CI や恒久的な regression coverage にしたいものだけを Playwright sp
 ## ドキュメントルール
 
 実装変更で既存ドキュメントが偽になったら、同じ変更で `docs/` を更新します。
+
+## PR ルール
+
+- PR 作成時は `.github/pull_request_template.md` を本文の起点として使います。
+- `gh pr create` では inline body string ではなく `--body-file` を使い、template を必要な内容で埋めます。
+- template に書かれた summary, changes, testing を実際の差分に合わせて更新してから PR を作成します。

--- a/tests/docs-structure.test.ts
+++ b/tests/docs-structure.test.ts
@@ -104,6 +104,21 @@ describe("documentation source of truth", () => {
     expect(agents).toContain("lint:framework");
   });
 
+  it("documents pull request template usage in AGENTS and workflow docs", () => {
+    const agents = readProjectFile("AGENTS.md");
+    const changeWorkflow = readProjectFile("docs/workflows/change-workflow.md");
+    const pullRequestTemplate = readProjectFile(
+      ".github/pull_request_template.md",
+    );
+
+    expect(agents).toContain("pull_request_template.md");
+    expect(agents).toContain("PR");
+    expect(changeWorkflow).toContain("pull_request_template.md");
+    expect(changeWorkflow).toContain("PR");
+    expect(pullRequestTemplate).toContain("## Summary");
+    expect(pullRequestTemplate).toContain("## Testing");
+  });
+
   it("documents project initialization decisions before implementation lock-in", () => {
     const initializeIndex = readProjectFile("docs/initialize/README.md");
     const technicalBaseline = readProjectFile(

--- a/tests/repository-structure.test.ts
+++ b/tests/repository-structure.test.ts
@@ -29,6 +29,9 @@ describe("ideal future repository structure", () => {
   });
 
   it("includes repository-level scaffolding for storybook and tests", () => {
+    expect(existsSync(projectPath(".github/pull_request_template.md"))).toBe(
+      true,
+    );
     expect(existsSync(projectPath(".storybook/main.ts"))).toBe(true);
     expect(existsSync(projectPath(".storybook/preview.ts"))).toBe(true);
     expect(existsSync(projectPath(".storybook/manager.ts"))).toBe(true);


### PR DESCRIPTION
## Summary

- リポジトリに PR template を追加
- agent / workflow docs に PR 作成時の template 利用ルールを追加
- template と運用ルールの存在を固定するテストを追加

## Changes

- `.github/pull_request_template.md` を追加
- `AGENTS.md` に `gh pr create --body-file` と template 利用ルールを追記
- `docs/workflows/change-workflow.md` に PR ルールを追記
- `tests/repository-structure.test.ts` に template 存在チェックを追加
- `tests/docs-structure.test.ts` に template / docs ルールの検証を追加

## Testing

- [x] `pnpm lint:framework`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm build`

## Notes

- `pre-push` で `pnpm lint:framework`, `pnpm test`, `pnpm build` を再実行して通過済み
